### PR TITLE
Add support for proxying nested objects 

### DIFF
--- a/demo/pnpm-lock.yaml
+++ b/demo/pnpm-lock.yaml
@@ -30,7 +30,7 @@ packages:
   '@bigmistqke/vite-plugin-worker-proxy@file:../vite-plugin-worker-proxy':
     resolution: {directory: ../vite-plugin-worker-proxy, type: directory}
     peerDependencies:
-      '@bigmistqke/worker-proxy': ^0.0.3
+      '@bigmistqke/worker-proxy': ^0.0.13
       vite: ^5.4.2
 
   '@bigmistqke/worker-proxy@file:../worker-proxy':

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,24 +1,38 @@
-// Vanilla worker-proxy
+/**********************************************************************************/
+/*                                                                                */
+/*                                 Vanilla Worker                                 */
+/*                                                                                */
+/**********************************************************************************/
+
 import { $callback, $transfer, createWorkerProxy } from '@bigmistqke/worker-proxy'
 import type VanillaMethods from './worker-vanilla.ts'
 import VanillaWorker from "./worker-vanilla.ts?worker"
 
 const vanillaWorker = createWorkerProxy<typeof VanillaMethods>(new VanillaWorker())
-vanillaWorker.ping(performance.now())
-const buffer1 = new ArrayBuffer()
 
+vanillaWorker.ping(performance.now())
+
+const buffer1 = new ArrayBuffer()
 vanillaWorker.transfer($transfer(buffer1, [buffer1]))
+
 vanillaWorker.logger.log('hello from vanilla worker')
 vanillaWorker.logger.test.$async.hello().then((world) => console.log('vanilla worker async method', world))
 
 vanillaWorker.callback((value) => console.log('callback from vanilla-worker', value))
 vanillaWorker.nestedCallback({cb: $callback((value: string) => console.log('nested callback from vanilla-worker', value))})
 
-// With vite-plugin
+
+/**********************************************************************************/
+/*                                                                                */
+/*                                With Vite Plugin                                */
+/*                                                                                */
+/**********************************************************************************/
+
 import type PluginMethods from './worker-plugin.ts'
 import PluginWorker from "./worker-plugin.ts?worker-proxy"
 
 const pluginWorker = new PluginWorker<typeof PluginMethods>()
+
 pluginWorker.ping(performance.now())
 
 const buffer = new ArrayBuffer()

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -11,6 +11,9 @@ vanillaWorker.transfer($transfer(buffer1, [buffer1]))
 vanillaWorker.logger.log('hello from vanilla worker')
 vanillaWorker.logger.test.$async.hello().then((world) => console.log('vanilla worker async method', world))
 
+vanillaWorker.callback((value) => console.log('callback from vanilla-worker', value))
+vanillaWorker.nestedCallback({cb: $callback((value: string) => console.log('nested callback from vanilla-worker', value))})
+
 // With vite-plugin
 import type PluginMethods from './worker-plugin.ts'
 import PluginWorker from "./worker-plugin.ts?worker-proxy"
@@ -21,13 +24,11 @@ pluginWorker.ping(performance.now())
 const buffer = new ArrayBuffer()
 pluginWorker.transfer($transfer(buffer, [buffer]))
 
-pluginWorker.plugins[0].log('hello from plugin worker')
-pluginWorker.plugins[0].test.$async.hello().then((world) => console.log('plugin worker async method', world))
+pluginWorker.logger.log('hello from plugin worker')
+pluginWorker.logger.test.$async.hello().then((world) => console.log('plugin worker async method', world))
 
-setInterval(async () => {
-  const cb = $callback((value: string) => console.log('ping', value))
-  await pluginWorker.$async.callback(cb)
-}, 500)
+pluginWorker.callback((value) => console.log('callback from plugin-worker', value))
+pluginWorker.nestedCallback({cb: $callback((value: string) => console.log('nested callback from plugin-worker', value))})
 
 
 

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -8,6 +8,8 @@ vanillaWorker.ping(performance.now())
 const buffer1 = new ArrayBuffer()
 
 vanillaWorker.transfer($transfer(buffer1, [buffer1]))
+vanillaWorker.logger.log('hello from vanilla worker')
+vanillaWorker.logger.test.$async.hello().then((world) => console.log('vanilla worker async method', world))
 
 // With vite-plugin
 import type PluginMethods from './worker-plugin.ts'
@@ -17,11 +19,16 @@ const pluginWorker = new PluginWorker<typeof PluginMethods>()
 pluginWorker.ping(performance.now())
 
 const buffer = new ArrayBuffer()
-
-
 pluginWorker.transfer($transfer(buffer, [buffer]))
 
+pluginWorker.plugins[0].log('hello from plugin worker')
+pluginWorker.plugins[0].test.$async.hello().then((world) => console.log('plugin worker async method', world))
+
 setInterval(async () => {
-  const cb = $callback((value: string) => console.log(value))
+  const cb = $callback((value: string) => console.log('ping', value))
   await pluginWorker.$async.callback(cb)
 }, 500)
+
+
+
+

--- a/demo/src/worker-plugin.ts
+++ b/demo/src/worker-plugin.ts
@@ -1,12 +1,31 @@
 import { type $Callback, $apply } from "@bigmistqke/worker-proxy"
+class Logger {
+  state = "ignore"
+  log(message: string){
+    console.log(message)
+  }
+  test = {
+    state: 'ignore',
+    another:  {
+      state: 'ignore'
+    },
+    hello(){
+      return "world" as const
+    }
+  }
+}
+
+const logger = new Logger()
+
 export default {
+  plugins: [logger],
   ping(timestamp: number) {
-    console.log('ping', timestamp)
+    console.log('ping from worker-plugin', timestamp)
   },
   callback(cb: $Callback<(message: string) => void>){
     $apply(cb, "hallo")
   },
   transfer(buffer: ArrayBuffer){
-    console.log(buffer)
+    console.log('transferred to worker-plugin', buffer)
   }
 }

--- a/demo/src/worker-plugin.ts
+++ b/demo/src/worker-plugin.ts
@@ -1,4 +1,5 @@
-import { type $Callback, $apply } from "@bigmistqke/worker-proxy"
+import { $apply, $Callback } from "@bigmistqke/worker-proxy"
+
 class Logger {
   state = "ignore"
   log(message: string){
@@ -15,15 +16,16 @@ class Logger {
   }
 }
 
-const logger = new Logger()
-
 export default {
-  plugins: [logger],
+  logger: new Logger(),
   ping(timestamp: number) {
     console.log('ping from worker-plugin', timestamp)
   },
-  callback(cb: $Callback<(message: string) => void>){
-    $apply(cb, "hallo")
+  callback(cb: (message: string) => void){
+    cb('hallo')
+  },
+  nestedCallback({cb}: {cb: $Callback<(message: string) => void>}){
+    $apply(cb, 'hallo')
   },
   transfer(buffer: ArrayBuffer){
     console.log('transferred to worker-plugin', buffer)

--- a/demo/src/worker-vanilla.ts
+++ b/demo/src/worker-vanilla.ts
@@ -1,10 +1,28 @@
-import { registerMethods } from "@bigmistqke/worker-proxy";
+import { registerMethods } from '@bigmistqke/worker-proxy'
+class Logger {
+  state = "ignore"
+  log(message: string){
+    console.log(message)
+  }
+  test = {
+    state: 'ignore',
+    more:  {
+      state: 'ignore'
+    },
+    hello(){
+      return "world" as const
+    }
+  }
+}
+
+const logger = new Logger()
 
 export default registerMethods({
+  logger,
   ping(timestamp: number) {
-    console.log('ping', timestamp)
+    console.log('ping from vanilla-worker', timestamp)
   },
   transfer(buffer: ArrayBuffer){
-    console.log(buffer)
+    console.log('transferred to vanilla-worker', buffer)
   }
 })

--- a/demo/src/worker-vanilla.ts
+++ b/demo/src/worker-vanilla.ts
@@ -1,4 +1,4 @@
-import { registerMethods } from '@bigmistqke/worker-proxy'
+import { $apply, $Callback, registerMethods } from '@bigmistqke/worker-proxy'
 class Logger {
   state = "ignore"
   log(message: string){
@@ -19,6 +19,12 @@ const logger = new Logger()
 
 export default registerMethods({
   logger,
+  callback(cb: (value: string) => void){
+    cb("hallo")
+  },
+  nestedCallback({cb}: {cb: $Callback<(message: string) => void>}){
+    $apply(cb, 'hallo')
+  },
   ping(timestamp: number) {
     console.log('ping from vanilla-worker', timestamp)
   },

--- a/vite-plugin-worker-proxy/README.md
+++ b/vite-plugin-worker-proxy/README.md
@@ -6,7 +6,6 @@ Vite plugin integration of `@bigmistqke/worker-proxy`, automatically wrapping th
 
 - [Getting Started](#getting-started)
 - [Basic Example](#basic-example)
-- [$on](#on) _Subscribe to calls_
 - [$transfer](#transfer) _Transfer `Transferables`_
 - [$async](#async) _Await responses of worker-methods_
 - [$port](#port) _Expose a WorkerProxy's api to another WorkerProxy_

--- a/vite-plugin-worker-proxy/README.md
+++ b/vite-plugin-worker-proxy/README.md
@@ -5,7 +5,7 @@ Vite plugin integration of `@bigmistqke/worker-proxy`, automatically wrapping th
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-- [Basic Example](#basics)
+- [Basic Example](#basic-example)
 - [$on](#on) _Subscribe to calls_
 - [$transfer](#transfer) _Transfer `Transferables`_
 - [$async](#async) _Await responses of worker-methods_
@@ -60,22 +60,69 @@ import Worker from './worker?worker-proxy'
 // Create WorkerProxy
 const worker = new Worker<typeof WorkerApi>()
 
-// Call log-method of worker
-worker.log('hello', 'bigmistqke')
+// Call ping-method of worker
+worker.ping()
+
+// Call log-method of worker.logger
+worker.logger.log('hello', 'bigmistqke')
 ```
 
 **worker.ts**
 
 ```tsx
-import { WorkerProps } from '@bigmistqke/worker-proxy'
-
-// Default export the methods you want to expose.
-export default {
+class Logger {
   log(...args: Array<string>) {
     console.log(...args)
   }
 }
+
+// Default export the methods you want to expose.
+export default {
+  logger: new Logger(),
+  ping() {
+    console.log('ping')
+  }
+}
 ```
+
+<details>
+<summary>Only **paths that lead to methods** are available from the worker-proxy.</summary>
+
+All non-function values (even deeply nested ones) are stripped out from the types.
+
+```ts
+// worker.ts
+export default {
+  state: 'ignore'
+  nested: {
+    state: 'ignore',
+    ignored: {
+      state: 'ignore'
+    },
+    method() {
+      return 'not ignored'
+    }
+  }
+}
+
+// main.ts
+import type Logger from './worker.ts'
+import Worker from './worker.ts?worker-proxy'
+
+const workerProxy = new Worker<Logger>()
+```
+
+The resulting type of `workerProxy` will be:
+
+```ts
+{
+  nested: {
+    method(): string
+  }
+}
+```
+
+</details>
 
 ## $async
 

--- a/vite-plugin-worker-proxy/client.d.ts
+++ b/vite-plugin-worker-proxy/client.d.ts
@@ -6,21 +6,51 @@ declare module '*?worker-proxy' {
 
   type Fn = (...arg: Array<any>) => any
 
-  type SyncMethods<T extends Record<string, Fn>> = {
-    [TKey in keyof T]: (...args: Parameters<T[TKey]> | [$Transfer<Parameters<T[TKey]>>]) => void
+  type SyncMethod<T extends Fn> = (...args: Parameters<T> | [$Transfer<Parameters<T>>]) => void
+  export type SyncMethods<T extends Record<string, Fn>> = {
+    [TKey in keyof T as T[TKey] extends Fn ? TKey : never]: SyncMethod<T[TKey]>
   }
-  type AsyncMethods<T extends Record<string, Fn>> = {
-    [TKey in keyof T]: (
-      ...args: Parameters<T[TKey]> | [$Transfer<Parameters<T[TKey]>>]
-    ) => Promise<ReturnType<T[TKey]>>
+
+  type AsyncMethod<T extends Fn> = (...args: Parameters<T>) => Promise<ReturnType<T>>
+  export type AsyncMethods<T extends Record<string, any>> = {
+    [TKey in keyof T as T[TKey] extends Fn ? TKey : never]: AsyncMethod<T[TKey]>
   }
-  type WorkerProxy<Methods extends Record<string, Fn>, Props = unknown> = SyncMethods<Methods> & {
-    $async: AsyncMethods<Methods>
-    $on: {
-      [TKey in keyof Props]: (data: Props[TKey]) => () => void
-    }
-    $port: () => WorkerProxyPort<Methods>
+
+  export type WorkerProps<T extends Record<string, Fn>> = SyncMethods<T> & {
+    $async: AsyncMethods<T>
   }
-  const workerApi: new <T>() => T extends Record<string, Fn> ? WorkerProxy<T> : never
+
+  type FilterMethods<T> = {
+    [TKey in keyof T as WorkerProxy<T[TKey]> extends never ? never : TKey]: T[TKey]
+  }
+
+  // To prevent error: `Type instantiation is excessively deep and possibly infinite.`
+  type isObject<T> = T extends object ? true : false
+
+  type HasMethod<T> = T extends object
+    ? {
+        [K in keyof T]: T[K] extends Fn ? true : HasMethod<T[K]>
+      }[keyof T] extends false
+      ? false
+      : true
+    : false
+
+  type WorkerProxy<T> = T extends Fn
+    ? SyncMethod<T>
+    : T extends readonly [any, ...any[]]
+    ? {
+        [TKey in keyof FilterMethods<T>]: WorkerProxy<T[TKey]>
+      } & { $async: AsyncMethods<FilterMethods<T>> }
+    : // To prevent error: `Type instantiation is excessively deep and possibly infinite.`
+    isObject<T> extends true
+    ? // Filter branches that lead to no method
+      HasMethod<T> extends false
+      ? never
+      : {
+          [TKey in keyof FilterMethods<T>]: WorkerProxy<T[TKey]>
+        } & { $async: AsyncMethods<FilterMethods<T>> }
+    : never
+
+  const workerApi: new <T>() => WorkerProxy<T>
   export default workerApi
 }

--- a/vite-plugin-worker-proxy/package.json
+++ b/vite-plugin-worker-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigmistqke/vite-plugin-worker-proxy",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "description": "Vite integration of @bigmistqke/worker-proxy.",
   "main": "./dist/index.cjs",
@@ -24,7 +24,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@bigmistqke/worker-proxy": "^0.0.11",
+    "@bigmistqke/worker-proxy": "^0.0.13",
     "vite": "^5.4.2"
   },
   "dependencies": {

--- a/vite-plugin-worker-proxy/package.json
+++ b/vite-plugin-worker-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigmistqke/vite-plugin-worker-proxy",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "description": "Vite integration of @bigmistqke/worker-proxy.",
   "main": "./dist/index.cjs",

--- a/vite-plugin-worker-proxy/package.json
+++ b/vite-plugin-worker-proxy/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.5.3"
   },
   "peerDependencies": {
-    "@bigmistqke/worker-proxy": "^0.0.3",
+    "@bigmistqke/worker-proxy": "^0.0.11",
     "vite": "^5.4.2"
   },
   "dependencies": {

--- a/worker-proxy/README.md
+++ b/worker-proxy/README.md
@@ -39,7 +39,7 @@ yarn add --dev @bigmistqke/worker-proxy
 **main.ts**
 
 ```tsx
-import type { Methods } from './worker.ts'
+import type Methods from './worker.ts'
 
 // Create WorkerProxy
 const worker = createWorkerProxy<Methods>(new Worker('./worker.ts'))
@@ -62,18 +62,14 @@ class Logger {
   }
 }
 
-const methods = {
+// Initialize worker-methods with registerMethods
+// Default export types of methods to infer the WorkerProxy's type
+export default registerMethods({
   logger: new Logger(),
   ping() {
     console.log('ping')
   },
-}
-
-// Initialize worker-methods
-registerMethods(methods)
-
-// Export types of methods to infer the WorkerProxy's type
-export type Methods = typeof methods
+})
 ```
 
 <details>

--- a/worker-proxy/README.md
+++ b/worker-proxy/README.md
@@ -5,7 +5,7 @@ Library to improve worker DX, similar to [ComLink](https://github.com/GoogleChro
 ## Table of Contents
 
 - [Getting Started](#getting-started)
-- [Basic Example](#basics)
+- [Basic Example](#basic-example)
 - [$transfer](#transfer) _Transfer `Transferables`_
 - [$async](#async) _Await responses of worker-methods_
 - [$port](#port) _Expose a WorkerProxy's api to another WorkerProxy_
@@ -44,8 +44,11 @@ import type { Methods } from './worker.ts'
 // Create WorkerProxy
 const worker = createWorkerProxy<Methods>(new Worker('./worker.ts'))
 
-// Call log-method of worker
-worker.log('hello', 'bigmistqke')
+// Call ping-method of worker
+worker.ping()
+
+// Call log-method of worker.logger
+worker.logger.log('hello', 'bigmistqke')
 ```
 
 **worker.ts**
@@ -53,9 +56,16 @@ worker.log('hello', 'bigmistqke')
 ```tsx
 import { type WorkerProps, registerMethods } from '@bigmistqke/worker-proxy'
 
-const methods = {
+class Logger {
   log(...args: Array<string>) {
     console.log(...args)
+  }
+}
+
+const methods = {
+  logger: new Logger(),
+  ping() {
+    console.log('ping')
   },
 }
 
@@ -65,6 +75,45 @@ registerMethods(methods)
 // Export types of methods to infer the WorkerProxy's type
 export type Methods = typeof methods
 ```
+
+<details>
+<summary>Only **paths that lead to methods** are available from the worker-proxy.</summary>
+
+All non-function values (even deeply nested ones) are stripped out from the types.
+
+```ts
+// worker.ts
+export default registerMethods({
+  state: 'ignore'
+  nested: {
+    state: 'ignore',
+    ignored: {
+      state: 'ignore'
+    },
+    method() {
+      return 'not ignored'
+    }
+  }
+})
+
+// main.ts
+import type Methods from './worker.ts'
+import Worker from './worker.ts?worker'
+
+const workerProxy = createWorkerProxy<Methods>(new Worker())
+```
+
+The resulting type of `workerProxy` will be:
+
+```ts
+{
+  nested: {
+    method(): string
+  }
+}
+```
+
+</details>
 
 ## $async
 

--- a/worker-proxy/package.json
+++ b/worker-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigmistqke/worker-proxy",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "description": "Improve worker DX with a proxy.",
   "module": "./dist/index.js",

--- a/worker-proxy/package.json
+++ b/worker-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigmistqke/worker-proxy",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "description": "Improve worker DX with a proxy.",
   "module": "./dist/index.js",

--- a/worker-proxy/src/types.ts
+++ b/worker-proxy/src/types.ts
@@ -8,23 +8,55 @@ export type $Callback<T = Fn> = T & { [$CALLBACK]: number }
 
 export type Fn = (...arg: Array<any>) => any
 
+type SyncMethod<T extends Fn> = (...args: Parameters<T> | [$Transfer<Parameters<T>>]) => void
 export type SyncMethods<T extends Record<string, Fn>> = {
-  [TKey in keyof T]: (...args: Parameters<T[TKey]> | [$Transfer<Parameters<T[TKey]>>]) => void
+  [TKey in keyof T as T[TKey] extends Fn ? TKey : never]: SyncMethod<T[TKey]>
 }
 
-export type AsyncMethods<T extends Record<string, Fn>> = {
-  [TKey in keyof T]: (...args: Parameters<T[TKey]>) => Promise<ReturnType<T[TKey]>>
+type AsyncMethod<T extends Fn> = (...args: Parameters<T>) => Promise<ReturnType<T>>
+export type AsyncMethods<T extends Record<string, any>> = {
+  [TKey in keyof T as T[TKey] extends Fn ? TKey : never]: AsyncMethod<T[TKey]>
 }
 
 export type WorkerProps<T extends Record<string, Fn>> = SyncMethods<T> & {
   $async: AsyncMethods<T>
 }
 
-export type WorkerProxy<T> = T extends Record<string, Fn>
-  ? SyncMethods<T> & {
-      $async: AsyncMethods<T>
-    }
+type FilterMethods<T> = {
+  [TKey in keyof T as WorkerProxy<T[TKey]> extends never ? never : TKey]: T[TKey]
+}
+
+// To prevent error: `Type instantiation is excessively deep and possibly infinite.`
+type isObject<T> = T extends object ? true : false
+
+type HasMethod<T> = T extends object
+  ? {
+      [K in keyof T]: T[K] extends Fn ? true : HasMethod<T[K]>
+    }[keyof T] extends false
+    ? false
+    : true
+  : false
+
+export type WorkerProxy<T> = T extends Fn
+  ? SyncMethod<T>
+  : T extends readonly [any, ...any[]] // is it a tuple?
+  ? { [K in keyof T]: WorkerProxy<T[K]> } // preserve tuple structure
+  : // To prevent error: `Type instantiation is excessively deep and possibly infinite.`
+  isObject<T> extends true
+  ? // Filter branches that lead to no method
+    HasMethod<T> extends false
+    ? never
+    : {
+        [TKey in keyof FilterMethods<T>]: WorkerProxy<T[TKey]>
+      } & { $async: AsyncMethods<FilterMethods<T>> }
   : never
 
 /** Branded `MessagePort` */
 export type WorkerProxyPort<T> = MessagePort & { $: T }
+
+export type Api =
+  | {
+      [key: string]: Fn | Api
+    }
+  | Array<Fn | Api>
+  | object


### PR DESCRIPTION
before
- expected the registered worker-methods to be Record<string, Fn>

after
- methods can also be (nested) objects
- worker-proxy returns nested proxy when an object is get
- when a proxy is applied, the traversed path is collected and passed to topics: Array<string>
- paths leading to no method are filtered from the types